### PR TITLE
Fixed caching bug: old Migration artifacts would overwrite newly deployed Migrations

### DIFF
--- a/resolverintercept.js
+++ b/resolverintercept.js
@@ -1,9 +1,15 @@
+const path = require("path");
+
 function ResolverIntercept(resolver) {
   this.resolver = resolver;
   this.cache = {};
 };
 
 ResolverIntercept.prototype.require = function(import_path) {
+  // Modify import_path so the cache key is consistently the same irrespective
+  // of whether a user explicated .sol extension
+  import_path = path.basename(import_path, ".sol");
+
   // TODO: Using the import path for relative files may result in multiple
   // paths for the same file. This could return different objects since it won't be a cache hit.
   if (this.cache[import_path]) {


### PR DESCRIPTION
Was facing bug in which `truffle migrate` would never save the newly deployed `Migrations.sol` contract's artifacts, meaning that the entire migration sequence would run from the beginning every time `truffle migrate` was called.

After some digging, it turns out `resolverIntercept.js` is the culprit.  In `index.js`, the following line results in the caching of an old, undeployed Migration artifact:
```javascript
      var Migrations = resolver.require("./Migrations.sol");
```

However, if your first migration retrieves the Migration contract as `artifacts.require('Migrations')` and not `artifacts.require('Migrations.sol')`, the resolver will cache a duplicate, newer copy of the Migrations artifacts at the key `Migrations` alongside the one already cached at `Migrations.sol`.

This is problematic because the artifactor uses the resolver's cache to list out which artifacts need to be written to disk -- hence, in alphabetical order, the new artifact associated with the `Migrations` key is written first, and then overwritten by the _old_ artifact associated with the `Migrations.sol` key.

This PR fixes the above by trimming away trailing import paths and `.sol` extensions from all cache keys.
