### PR TITLE
Add check for Migrations.sol variants

### DIFF
--- a/index.js
+++ b/index.js
@@ -257,7 +257,11 @@ var Migrate = {
     var migrations = Migrations.deployed();
 
     Migrations.deployed().then(function(migrations) {
-      return migrations.last_completed_migration.call();
+      // Two possible Migrations.sol's (lintable/unlintable)
+      return (migrations.last_completed_migration)
+        ? migrations.last_completed_migration.call()
+        : migrations.lastCompletedMigration.call();
+
     }).then(function(completed_migration) {
       callback(null, completed_migration.toNumber());
     }).catch(callback);


### PR DESCRIPTION
Addresses #19. Checks which variant of Migrations.sol is being called when accessing the `last_completed_migrations` variable from the contract.

