### PR TITLE
Upgrade to web3 1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,22 +67,26 @@ Migration.prototype.run = function(options, callback) {
     });
   };
 
-  web3.eth.getAccounts(function(err, accounts) {
-    if (err) return callback(err);
+  web3
+    .eth
+    .getAccounts()
+    .then(accounts => {
 
-    Require.file({
-      file: self.file,
-      context: context,
-      resolver: resolver,
-      args: [deployer],
-    }, function(err, fn) {
-      if (!fn || !fn.length || fn.length == 0) {
-        return callback(new Error("Migration " + self.file + " invalid or does not take any parameters"));
-      }
-      fn(deployer, options.network, accounts);
-      finish();
-    });
-  });
+      Require.file({
+        file: self.file,
+        context: context,
+        resolver: resolver,
+        args: [deployer],
+      }, function(err, fn) {
+        if (!fn || !fn.length || fn.length == 0) {
+          return callback(new Error("Migration " + self.file + " invalid or does not take any parameters"));
+        }
+        fn(deployer, options.network, accounts);
+        finish();
+      });
+
+    })
+    .catch(callback);
 };
 
 var Migrate = {
@@ -205,17 +209,8 @@ var Migrate = {
     };
 
     return {
-      send: function(payload) {
-        var result = provider.send(payload);
-
-        if (payload.method == "eth_sendTransaction") {
-          printTransaction(result.result);
-        }
-
-        return result;
-      },
-      sendAsync: function(payload, callback) {
-        provider.sendAsync(payload, function(err, result) {
+      send: function(payload, callback) {
+        provider.send(payload, function(err, result) {
           if (err) return callback(err);
 
           if (payload.method == "eth_sendTransaction") {

--- a/index.js
+++ b/index.js
@@ -257,13 +257,9 @@ var Migrate = {
     var migrations = Migrations.deployed();
 
     Migrations.deployed().then(function(migrations) {
-      // Two possible Migrations.sol's (lintable/unlintable)
-      return (migrations.last_completed_migration)
-        ? migrations.last_completed_migration.call()
-        : migrations.lastCompletedMigration.call();
-
+      return migrations.last_completed_migration.call();
     }).then(function(completed_migration) {
-      callback(null, completed_migration.toNumber());
+      callback(null, parseInt(completed_migration));
     }).catch(callback);
   },
 

--- a/index.js
+++ b/index.js
@@ -257,7 +257,11 @@ var Migrate = {
     var migrations = Migrations.deployed();
 
     Migrations.deployed().then(function(migrations) {
-      return migrations.last_completed_migration.call();
+      // Two possible Migrations.sol's (lintable/unlintable)
+      return (migrations.last_completed_migration)
+        ? migrations.last_completed_migration.call()
+        : migrations.lastCompletedMigration.call();
+
     }).then(function(completed_migration) {
       callback(null, parseInt(completed_migration));
     }).catch(callback);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "truffle-deployer": "^2.0.4",
     "truffle-expect": "^0.0.3",
     "truffle-require": "^1.0.5",
-    "web3": "^0.20.1"
+    "web3": "1.0.0-beta.33"
   },
   "devDependencies": {
     "mocha": "^3.2.0"


### PR DESCRIPTION
+ Substitutes `parseInt` for BigNumber's `.toNumber` method because web3 1.0 now returns these values as strings rather than BN objects. NB: Assumes that no one's migrations count will ever climb into BigNumber territory. 
+ Removes references to `provider.sendAsync`. Web3 1.0 is all async and has renamed this method to `send`.