### PR TITLE
Fix support for contracts from npm packages due to import_path normalization bug

### DIFF
--- a/resolverintercept.js
+++ b/resolverintercept.js
@@ -8,7 +8,7 @@ function ResolverIntercept(resolver) {
 ResolverIntercept.prototype.require = function(import_path) {
   // Modify import_path so the cache key is consistently the same irrespective
   // of whether a user explicated .sol extension
-  import_path = path.basename(import_path, ".sol");
+  import_path = import_path.replace(/\.sol$/i, '');
 
   // TODO: Using the import path for relative files may result in multiple
   // paths for the same file. This could return different objects since it won't be a cache hit.


### PR DESCRIPTION
Ref: trufflesuite/truffle#901

PR #18 normalized the caching key for artifacts but was too aggressive with the normalization. Instead of trimming the ".sol" it would also trim the entire path including an external package name when used in a migration to link to an outside package with a contract such as

```js
var OtherContract = artifacts.require('other/contracts/OtherContract')
```

the current code post v4.1.3 and a bug that remains in the latest release, will normalize the above import_path to "OtherContract".

this is problematic because in the truffle-resolver of the NPM code, https://github.com/trufflesuite/truffle-resolver/blob/develop/npm.js#L17 the package_name is parsed from the import_path, which in this case is being clobbered, and as a result OtherContract is unable to be found, breaking support for contracts from npm packages

this PR fixes it by only trimming the `.sol` extension and leaving the import_path otherwise untouched