### PR TITLE
Await the migration really is done

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,8 +79,12 @@ Migration.prototype.run = function(options, callback) {
       if (!fn || !fn.length || fn.length == 0) {
         return callback(new Error("Migration " + self.file + " invalid or does not take any parameters"));
       }
-      fn(deployer, options.network, accounts);
-      finish();
+      const result = fn(deployer, options.network, accounts);
+      if (result.then) {
+        result.then(finish)
+      } else {
+        finish();
+      }
     });
   });
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "async": "^2.1.4",
     "node-dir": "^0.1.16",
-    "truffle-deployer": "^2.0.3",
+    "truffle-deployer": "^2.0.4",
     "truffle-expect": "^0.0.3",
     "truffle-require": "^1.0.5",
     "web3": "^0.20.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-migrate",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "On-chain migrations management",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-migrate",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "On-chain migrations management",
   "main": "index.js",
   "scripts": {

--- a/resolverintercept.js
+++ b/resolverintercept.js
@@ -8,7 +8,7 @@ function ResolverIntercept(resolver) {
 ResolverIntercept.prototype.require = function(import_path) {
   // Modify import_path so the cache key is consistently the same irrespective
   // of whether a user explicated .sol extension
-  import_path = path.basename(import_path, ".sol");
+  import_path = import_path.replace(/\.sol$/i, '');
 
   // TODO: Using the import path for relative files may result in multiple
   // paths for the same file. This could return different objects since it won't be a cache hit.


### PR DESCRIPTION
What happens currently: (async) migration awaits for things like smart contract calls, fails, but still the `finish()` function is called an migration is marked as successful in the blockchain. That's just bad.