### PR TITLE
Add promises support in migrations

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,8 +79,16 @@ Migration.prototype.run = function(options, callback) {
       if (!fn || !fn.length || fn.length == 0) {
         return callback(new Error("Migration " + self.file + " invalid or does not take any parameters"));
       }
-      fn(deployer, options.network, accounts);
-      finish();
+      var migrationExecutionResult = fn(deployer, options.network, accounts);
+      if (migrationExecutionResult instanceof Object && migrationExecutionResult.then instanceof Function) {
+          migrationExecutionResult.then(function () {
+            finish();
+          }, function (err) {
+            finish(err);
+          })
+      } else {    
+        finish();
+      }
     });
   });
 };


### PR DESCRIPTION
Motivation: sometimes some async actions should be performed within migration (e.g. fetch remote server to get contract creation arguments); right now it is impossible (at least without some complicated and not user-friendly tricks). With this fix syntax like 
```javascript 
module.exports = async (deployer) => {
  const args = await fetchArgs();
  deployer.deploy(contract, ...args);
}
```
becomes available.